### PR TITLE
Removed bug for Mac and Linux

### DIFF
--- a/src/MatlabTerminal.ts
+++ b/src/MatlabTerminal.ts
@@ -33,7 +33,7 @@ export default class MatlabTerminal {
             if (process.platform === 'win32') {
                 this.terminal.sendText(`${this.matlabCommand} ${this.noSplashArg} ${this.noDesktopArg} -r "run('${relativeFilePath}');"`);
             } else {
-                this.terminal.sendText(`${rerun}run('${relativeFilePath}')`);
+                this.terminal.sendText(`run('${relativeFilePath}')`);
             }
         }
         this.terminal.show(true);


### PR DESCRIPTION
Didn't removed references to removed variable.

`${rerun}` wasn't working, since not declared.